### PR TITLE
Fix geteuid compile error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "const.h"
 #include "mainwindow.h"
 #include "iconloader.h"
+#include <unistd.h>
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
main.cpp:27:19: error: ‘geteuid’ was not declared in this scope
